### PR TITLE
Update site for invite-only early access

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const columns = [
     links: [
       { href: "/product", label: "What is Loremaster" },
       { href: "/faq", label: "FAQ" },
-      { href: "https://app.askloremaster.com", label: "Try Loremaster Free", external: true },
+      { href: "mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!", label: "Request Early Access" },
       // { href: "/changelog", label: "Changelog" },
     ],
   },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,6 +7,7 @@ const { currentPath } = Astro.props;
 
 const navLinks = [
   { href: "/product", label: "What is Loremaster" },
+  { href: "/pricing", label: "Pricing" },
   { href: "/faq", label: "FAQ" },
 ];
 ---
@@ -52,9 +53,15 @@ const navLinks = [
       }
       <a
         href="https://app.askloremaster.com"
+        class="inline-flex items-center rounded-[10px] border border-accent/40 px-4 py-2 text-[14px] font-semibold text-accent no-underline transition-all duration-200 hover:-translate-y-px hover:border-accent hover:bg-accent/10"
+      >
+        Log In
+      </a>
+      <a
+        href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
         class="inline-flex items-center rounded-[10px] bg-accent px-4 py-2 text-[14px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_8px_24px_rgba(218,160,64,0.2)]"
       >
-        Try Loremaster Free
+        Request Early Access
       </a>
     </div>
 
@@ -101,9 +108,15 @@ const navLinks = [
       }
       <a
         href="https://app.askloremaster.com"
+        class="mobile-nav-link mt-1 inline-flex items-center justify-center rounded-[10px] border border-accent/40 px-4 py-2.5 text-[15px] font-semibold text-accent no-underline transition-colors hover:border-accent hover:bg-accent/10"
+      >
+        Log In
+      </a>
+      <a
+        href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
         class="mobile-nav-link mt-1 inline-flex items-center justify-center rounded-[10px] bg-accent px-4 py-2.5 text-[15px] font-semibold text-[#1a1520] no-underline"
       >
-        Try Loremaster Free
+        Request Early Access
       </a>
     </div>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,13 +23,12 @@ import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
       <div class="hero-cascade mt-10">
         <a
           class="inline-flex items-center gap-2.5 rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-          href="https://app.askloremaster.com"
+          href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
         >
-          Try Loremaster Free
-          <span class="rounded-full bg-[#1a1520]/15 px-2 py-0.5 text-[10px] tracking-wide uppercase">Early Access</span>
+          Request Early Access
         </a>
       </div>
-      <p class="hero-cascade mt-4 text-[14px] text-text-muted">Free to start. No credit card required.</p>
+      <p class="hero-cascade mt-4 text-[14px] text-text-muted">Loremaster is currently in invite-only early access.</p>
     </section>
 
     <!-- Hero Session Carousel -->
@@ -164,16 +163,16 @@ import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
     <!-- CTA Banner -->
     <div class="reveal pb-16 md:pb-24">
       <GlassCard class="p-[clamp(2.5rem,2rem+2vw,4rem)] text-center">
-        <h2 class="text-[clamp(1.6rem,1.2rem+2vw,2.4rem)]">Start your next session with a recap</h2>
+        <h2 class="text-[clamp(1.6rem,1.2rem+2vw,2.4rem)]">Want to try Loremaster?</h2>
         <p class="mx-auto mt-4 max-w-[50ch] text-[17px] text-text-body">
-          Upload your last session and see what Loremaster generates for your campaign in seconds.
+          We're onboarding new groups during early access. Reach out and we'll get you set up.
         </p>
         <div class="mt-8">
           <a
             class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-            href="https://app.askloremaster.com"
+            href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
           >
-            Try Loremaster Free
+            Request Early Access
           </a>
         </div>
       </GlassCard>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -13,14 +13,17 @@ import GlassCard from "../components/GlassCard.astro";
         <h1 class="text-[clamp(2rem,1.4rem+3vw,3rem)] font-bold">Pricing</h1>
         <div class="gold-divider my-6"></div>
         <p class="voice max-w-[70ch] text-[clamp(1.1rem,1rem+0.5vw,1.3rem)]">
-          Pricing details are coming soon. In the meantime, you can try Loremaster for free.
+          Loremaster is currently in invite-only early access. During this period, all features are free for testers.
+        </p>
+        <p class="mt-4 max-w-[70ch] text-[16px] leading-[1.75] text-text-body">
+          We're working closely with early access groups to shape pricing before launch. If you'd like to try Loremaster with your group, reach out and we'll get you set up.
         </p>
         <div class="mt-8">
           <a
             class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-            href="https://app.askloremaster.com"
+            href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
           >
-            Try Loremaster Free
+            Request Early Access
           </a>
         </div>
       </GlassCard>

--- a/src/pages/product.astro
+++ b/src/pages/product.astro
@@ -26,11 +26,10 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       </p>
       <div class="mt-9">
         <a
-          class="inline-flex items-center gap-2.5 rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-          href="https://app.askloremaster.com"
+          class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
+          href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
         >
-          Try Loremaster Free
-          <span class="rounded-full bg-[#1a1520]/15 px-2 py-0.5 text-[10px] tracking-wide uppercase">Early Access</span>
+          Request Early Access
         </a>
       </div>
     </section>
@@ -187,16 +186,16 @@ import TimelineDemo from "../components/TimelineDemo.astro";
 
     <!-- CTA (open, centered) -->
     <section class="reveal mx-auto max-w-[600px] py-20 text-center md:py-28">
-      <h2 class="text-[clamp(1.6rem,1.2rem+2vw,2.4rem)]">Start your adventure</h2>
+      <h2 class="text-[clamp(1.6rem,1.2rem+2vw,2.4rem)]">Want to try Loremaster?</h2>
       <div class="gold-divider-animated mx-auto mt-4 mb-6"></div>
       <p class="mb-8 text-[17px] text-text-body">
-        Loremaster is ready to help you tell richer stories. Try it today.
+        We're onboarding new groups during early access. Reach out and we'll get you set up.
       </p>
       <a
         class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-        href="https://app.askloremaster.com"
+        href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
       >
-        Try Loremaster Free
+        Request Early Access
       </a>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- Replace all "Try Loremaster Free" CTAs with "Request Early Access" mailto links (prepopulated subject/body to contact@valfarandsons.com)
- Add "Log In" button (gold outline style) to header navbar, linking to app.askloremaster.com
- Add Pricing page back to header navigation
- Rewrite pricing page copy to reflect invite-only early access (free for testers)
- Update bottom CTA sections on homepage and product page with invite-friendly copy

## Test plan
- [ ] Verify all "Request Early Access" buttons open email client with correct subject/body
- [x] Verify "Log In" button appears in both desktop and mobile nav, links to app
- [x] Verify Pricing appears in nav and page copy reflects early access
- [x] Check mobile hamburger menu still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)