### PR TITLE
Point early access CTAs to Clerk waitlist

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const columns = [
     links: [
       { href: "/product", label: "What is Loremaster" },
       { href: "/faq", label: "FAQ" },
-      { href: "mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!", label: "Request Early Access" },
+      { href: "https://accounts.askloremaster.com/waitlist", label: "Request Early Access" },
       // { href: "/changelog", label: "Changelog" },
     ],
   },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -58,7 +58,7 @@ const navLinks = [
         Log In
       </a>
       <a
-        href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+        href="https://accounts.askloremaster.com/waitlist"
         class="inline-flex items-center rounded-[10px] bg-accent px-4 py-2 text-[14px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_8px_24px_rgba(218,160,64,0.2)]"
       >
         Request Early Access
@@ -113,7 +113,7 @@ const navLinks = [
         Log In
       </a>
       <a
-        href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+        href="https://accounts.askloremaster.com/waitlist"
         class="mobile-nav-link mt-1 inline-flex items-center justify-center rounded-[10px] bg-accent px-4 py-2.5 text-[15px] font-semibold text-[#1a1520] no-underline"
       >
         Request Early Access

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
       <div class="hero-cascade mt-10">
         <a
           class="inline-flex items-center gap-2.5 rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-          href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+          href="https://accounts.askloremaster.com/waitlist"
         >
           Request Early Access
         </a>
@@ -182,7 +182,7 @@ import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
         <div class="mt-8">
           <a
             class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-            href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+            href="https://accounts.askloremaster.com/waitlist"
           >
             Request Early Access
           </a>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -69,7 +69,7 @@ const included = [
         <div class="mt-8">
           <a
             class="inline-flex w-full items-center justify-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-            href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+            href="https://accounts.askloremaster.com/waitlist"
           >
             Request Early Access
           </a>

--- a/src/pages/product.astro
+++ b/src/pages/product.astro
@@ -27,7 +27,7 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       <div class="mt-9">
         <a
           class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-          href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+          href="https://accounts.askloremaster.com/waitlist"
         >
           Request Early Access
         </a>
@@ -193,7 +193,7 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       </p>
       <a
         class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"
-        href="mailto:contact@valfarandsons.com?subject=Loremaster%20Early%20Access%20Request&body=Hi%2C%20I%27d%20like%20to%20request%20early%20access%20to%20Loremaster.%20Thanks!"
+        href="https://accounts.askloremaster.com/waitlist"
       >
         Request Early Access
       </a>


### PR DESCRIPTION
## Summary
- Replace all "Request Early Access" mailto links with the Clerk waitlist URL (`accounts.askloremaster.com/waitlist`)
- Updated across: homepage, product page, pricing page, header (desktop + mobile), and footer

## Test plan
- [ ] Verify all "Request Early Access" buttons navigate to the waitlist page
- [ ] Confirm the waitlist page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)