### PR TITLE
Add drop cap to voice quote on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,7 +66,10 @@ import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
           class="voice-gradient text-[clamp(1.15rem,1rem+0.8vw,1.5rem)] leading-[1.75]"
           style="font-family: var(--font-voice); font-style: italic;"
         >
-          The salt air has a way of binding strangers together. After a heavy night in Saltmarsh, Migli, Durn, and Joren faced a goblin ambush on the road to Seagrove. Though blood was spilled and Migli nearly fell, they stood their ground, learning quickly that the path ahead demands more than just shared gold.
+          <span
+            class="voice-gradient float-left font-bold"
+            style="font-family: var(--font-voice-display); font-style: normal; font-size: 3.65em; line-height: 0.85; margin-right: 0.08em; margin-top: 0.06em;"
+          >T</span>he salt air has a way of binding strangers together. After a heavy night in Saltmarsh, Migli, Durn, and Joren faced a goblin ambush on the road to Seagrove. Though blood was spilled and Migli nearly fell, they stood their ground, learning quickly that the path ahead demands more than just shared gold.
         </p>
       </div>
       <p class="mt-4 text-center text-[14px] text-text-muted">


### PR DESCRIPTION
## Summary
- Add drop cap styling to the Loremaster voice quote block on the homepage
- Matches the `LoremasterVoice` component's `dropCap` prop from the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)