### PR TITLE
Increase brand name size in header and footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -43,7 +43,7 @@ const columns = [
             width="32"
             height="32"
           />
-          <span class="text-[14px] font-semibold text-text-primary">Loremaster</span>
+          <span class="text-[19px] font-bold leading-none text-text-primary" style="margin-bottom: 2px;">Loremaster</span>
         </a>
         <p class="mt-2 max-w-[28ch] text-[13px] leading-relaxed text-text-muted">
           AI-powered tools for tabletop storytelling.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,8 +30,8 @@ const navLinks = [
         width="40"
         height="40"
       />
-      <span class="text-text-primary text-[15px] font-semibold">Loremaster</span>
-      <span class="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-accent uppercase">Early Access</span>
+      <span class="text-text-primary text-[24px] font-bold leading-none" style="margin-bottom: 3px;">Loremaster</span>
+      <span class="rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-accent uppercase self-center">Early Access</span>
     </a>
 
     <!-- Desktop nav links -->


### PR DESCRIPTION
## Summary
- Increase "Loremaster" text size in header (15px → 24px) and footer (14px → 19px)
- Adjust alignment so text and Early Access badge sit correctly next to the logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)