### PR TITLE
Add speaker identification compliance to legal pages

### DIFF
--- a/src/layouts/LegalLayout.astro
+++ b/src/layouts/LegalLayout.astro
@@ -42,6 +42,7 @@ const { title, description, lastUpdated } = Astro.props;
     color: var(--lm-text-primary);
     margin-top: 2.5rem;
     margin-bottom: 0.75rem;
+    scroll-margin-top: 5rem;
   }
 
   .legal-content :global(h3) {
@@ -50,6 +51,7 @@ const { title, description, lastUpdated } = Astro.props;
     color: var(--lm-text-primary);
     margin-top: 1.75rem;
     margin-bottom: 0.5rem;
+    scroll-margin-top: 5rem;
   }
 
   .legal-content :global(p) {

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -5,7 +5,7 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 <LegalLayout
   title="Privacy Policy"
   description="Learn how Loremaster protects your campaign data, what we collect, and how we handle audio recordings and session content."
-  lastUpdated="March 27, 2026"
+  lastUpdated="April 5, 2026"
 >
   <p>
     This Privacy Policy explains how Valfar and Sons, Inc. ("Valfar and Sons," "we," "us," or
@@ -64,6 +64,12 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <ul>
     <li>Audio recordings (including associated file metadata such as duration, time uploaded, and file size)</li>
   </ul>
+  <p>
+    Audio submitted for transcription may be processed using speaker identification
+    (diarization) technology that analyzes vocal characteristics to distinguish between
+    speakers. For details on how speaker identification data is handled, see
+    <a href="#speaker-identification">Section 1H (Speaker Identification Processing)</a> below.
+  </p>
 
   <h3>E) Transcripts</h3>
   <p>If you use transcription features, we may collect and store:</p>
@@ -94,6 +100,28 @@ import LegalLayout from "../layouts/LegalLayout.astro";
     <li>Performance metrics (latency, feature reliability)</li>
     <li>Cookies or similar technologies (as needed for login sessions and basic functionality)</li>
   </ul>
+
+  <h3 id="speaker-identification">H) Speaker Identification Processing</h3>
+  <p>
+    When you use transcription features, Loremaster may process uploaded audio using
+    speaker identification (diarization) to generate speaker-labeled transcripts. This
+    process analyzes vocal characteristics to distinguish between different speakers in
+    a recording.
+  </p>
+  <p>
+    Speaker identification data is retained as part of the transcript. For details on
+    how long this data is kept and when it is deleted, see
+    <a href="#speaker-id-retention">Speaker Identification Data Retention</a> below.
+  </p>
+  <p>
+    Audio is sent to a third-party provider for processing. For details on which
+    providers we use, see our <a href="/subprocessors">Subprocessors page</a>.
+  </p>
+  <p>
+    You are responsible for obtaining consent from all speakers before uploading audio
+    for transcription. For more on your consent obligations, see
+    <a href="/terms#speaker-identification">Section 5.6 of our Terms of Service</a>.
+  </p>
 
   <h2>2) How We Use Your Information</h2>
   <p>We use the information we collect for the following purposes:</p>
@@ -164,6 +192,27 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <p>
     <strong>Note:</strong> Deletion may not be immediate and may take time to fully propagate
     through our systems, including backups.
+  </p>
+
+  <h3 id="speaker-id-retention">Speaker Identification Data Retention</h3>
+  <p>
+    Speaker identification data generated during diarization is retained as part of
+    the transcript. The related data that you control is retained as follows:
+  </p>
+  <ul>
+    <li>
+      <strong>Audio recordings:</strong> retained until you delete them through the
+      Service or request deletion by contacting us.
+    </li>
+    <li>
+      <strong>Transcripts (including speaker identification data and speaker labels):</strong>
+      retained until you delete them through the Service or request data deletion.
+    </li>
+  </ul>
+  <p>
+    Upon data deletion, all associated audio, transcripts, and speaker identification
+    data are deleted, except where retention is required for legal compliance, dispute
+    resolution, or backup integrity.
   </p>
 
   <h2>5) How We Share Information (Third Parties / Subprocessors)</h2>

--- a/src/pages/subprocessors.astro
+++ b/src/pages/subprocessors.astro
@@ -16,7 +16,7 @@ const subprocessors = [
   },
   {
     name: "Google Cloud Platform (GCP)",
-    purpose: "Hosting, infrastructure, data storage, and AI processing",
+    purpose: "Hosting, infrastructure, data storage, AI processing, and audio processing",
   },
   {
     name: "Google (Workspace & Services)",
@@ -40,7 +40,7 @@ const subprocessors = [
 <LegalLayout
   title="Subprocessors"
   description="Third-party services Loremaster uses to process data, including hosting, payments, and authentication providers."
-  lastUpdated="March 27, 2026"
+  lastUpdated="April 5, 2026"
 >
   <p>
     Loremaster is built by Valfar and Sons, Inc. We use a small number of trusted third-party

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -5,7 +5,7 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 <LegalLayout
   title="Terms of Service"
   description="Review Loremaster's terms of service, including data ownership, AI-generated content, and acceptable use."
-  lastUpdated="March 27, 2026"
+  lastUpdated="April 5, 2026"
 >
   <p>
     These Terms of Service ("Terms") govern your access to and use of the Loremaster platform and
@@ -113,6 +113,7 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <ul>
     <li>Record audio,</li>
     <li>Upload audio recordings,</li>
+    <li>Submit audio for processing using speaker identification (diarization) technology,</li>
     <li>Upload transcripts,</li>
     <li>Upload notes or other content relating to other individuals, and</li>
     <li>Use the Service in connection with any third-party content or personal information.</li>
@@ -131,6 +132,38 @@ import LegalLayout from "../layouts/LegalLayout.astro";
     <li>Includes confidential information you do not have the right to disclose, or</li>
     <li>Contains malware or other harmful code.</li>
   </ul>
+
+  <h3 id="speaker-identification">5.6 Speaker Identification (Diarization)</h3>
+  <p>
+    The Service may use speaker identification (diarization) technology to generate
+    speaker-labeled transcripts from uploaded audio. This process analyzes vocal
+    characteristics to distinguish between speakers in a recording.
+  </p>
+  <p>
+    Speaker identification data is retained as part of the transcript. For details on
+    data retention and deletion, see our
+    <a href="/privacy#speaker-id-retention">Privacy Policy</a>.
+  </p>
+  <p>
+    By submitting audio for transcription, you represent and warrant that you have:
+  </p>
+  <ul>
+    <li>
+      Provided notice to all speakers that their audio will be analyzed using speaker
+      identification technology,
+    </li>
+    <li>
+      Informed all speakers that the purpose of this analysis is to generate
+      speaker-labeled transcripts, and
+    </li>
+    <li>
+      Obtained consent from each speaker for this processing.
+    </li>
+  </ul>
+  <p>
+    You are solely responsible for compliance with all applicable laws regarding
+    speaker identification, including any notice and consent requirements.
+  </p>
 
   <h2>6. Acceptable Use and Abuse Policy</h2>
   <p>You may use the Service only for lawful purposes and in compliance with these Terms.</p>
@@ -403,6 +436,13 @@ import LegalLayout from "../layouts/LegalLayout.astro";
     <li>Your failure to obtain valid consent or permissions, or</li>
     <li>Your violation of these Terms or any applicable law.</li>
   </ul>
+  <p>
+    Without limiting the above, you specifically agree to indemnify and hold harmless
+    Valfar and Sons from any claims, liabilities, damages, losses, and expenses arising
+    from or related to the processing of audio using speaker identification technology,
+    including claims that you failed to provide adequate notice to speakers or failed to
+    obtain valid consent for speaker identification processing.
+  </p>
 
   <h2>17. Governing Law and Venue</h2>
   <p>


### PR DESCRIPTION
## Summary
- **Privacy Policy**: Added Section 1H (Speaker Identification Processing) and retention schedule; updated Section 1D to reference diarization
- **Terms of Service**: Added Section 5.6 (Speaker Identification) with consent representations/warranties; expanded Section 5.4; added specific indemnification in Section 16
- **Subprocessors**: Updated GCP purpose to include audio processing
- All pages updated to April 5, 2026 with cross-references between sections
- Added `scroll-margin-top` to LegalLayout headings for anchor link navigation

## Test plan
- [x] `npm run build` passes
- [x] Privacy Policy renders with new Section 1H and retention schedule
- [x] Terms of Service renders with new Section 5.6 and updated indemnification
- [x] Subprocessors page shows updated GCP purpose
- [x] All three pages show "Last Updated: April 5, 2026"
- [x] Cross-reference anchor links navigate correctly and headings aren't hidden behind the fixed header

🤖 Generated with [Claude Code](https://claude.com/claude-code)