### PR TITLE
feat: update homepage title for SEO keywords

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import FeatureCard from "../components/FeatureCard.astro";
 import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
 ---
 
-<BaseLayout title="Loremaster — AI Tools for Tabletop Storytelling" description="Loremaster records your D&D and TTRPG sessions, generates cinematic recaps, tracks NPCs and locations, and lets you chat with AI about your campaign. Free during early access." jsonLd={{
+<BaseLayout title="Loremaster — AI Campaign Tracker for D&D & TTRPGs" description="Loremaster records your D&D and TTRPG sessions, generates cinematic recaps, tracks NPCs and locations, and lets you chat with AI about your campaign. Free during early access." jsonLd={{
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "Loremaster",


### PR DESCRIPTION
## Summary
- Updates homepage `<title>` from "Loremaster — AI Tools for Tabletop Storytelling" to "Loremaster — AI Campaign Tracker for D&D & TTRPGs" (51 chars)
- Targets high-volume search terms ("D&D", "TTRPGs", "campaign tracker") that were missing from the title tag
- No visible copy changes on the page itself — only affects the browser tab, search results snippet, and social share title

## Test plan
- [x] Verify browser tab shows updated title
- [x] Check page source for correct `<title>`, `og:title`, and `twitter:title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)