### PR TITLE
chore: disallow /static/unlisted/ in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /releases.json
+Disallow: /static/unlisted/
 
 Sitemap: https://www.askloremaster.com/sitemap-index.xml


### PR DESCRIPTION
## What
Adds `Disallow: /static/unlisted/` to `public/robots.txt`.

## Why
The `public/static/unlisted/` folder holds link-shareable-but-not-advertised PDFs (alpha data use policy, welcome doc). They were publicly crawlable and not excluded from search indexes. This keeps them out of search results while still being reachable by direct link.

Directory-level rule so anything added to the folder later is covered automatically.

## Notes
- `robots.txt` blocks crawling, not access — these files remain fetchable by direct URL (which matches the "unlisted" intent).
- Not related to any current feature work; surfaced while auditing the repo for sensitive content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)