### PR TITLE
Refine About page: first names and warmer copy

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,8 +16,8 @@ import TeamCard from "../components/TeamCard.astro";
       </h1>
       <div class="gold-divider-animated mx-auto mt-5 mb-8"></div>
       <p class="voice text-[clamp(1.1rem,1rem+0.5vw,1.3rem)]">
-        We're builders, researchers, and storytellers, experienced in AI and software engineering
-        and united by a shared love of tabletop RPGs.
+        We're builders, researchers, and storytellers. We know AI and software engineering, and we
+        love tabletop RPGs.
       </p>
     </section>
 
@@ -30,19 +30,19 @@ import TeamCard from "../components/TeamCard.astro";
       <div class="reveal-stagger mx-auto grid max-w-[1000px] gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <div class="reveal">
           <TeamCard
-            name="Mark Derdzinski"
+            name="Mark"
             bio="Brings deep experience leading AI engineering teams and designing agentic systems for real-world software applications."
           />
         </div>
         <div class="reveal">
           <TeamCard
-            name="Daniel Ben-Zion"
+            name="Daniel"
             bio="Combines expertise in large-scale machine learning systems with a hands-on approach to building robust, production-ready AI infrastructure."
           />
         </div>
         <div class="reveal">
           <TeamCard
-            name="Garrett Bredell"
+            name="Garrett"
             bio="Draws on a background in product design and user research to create intuitive tools that support imaginative play."
           />
         </div>
@@ -56,7 +56,8 @@ import TeamCard from "../components/TeamCard.astro";
       <h2 class="text-[clamp(1.6rem,1.2rem+2vw,2.4rem)]">Get in Touch</h2>
       <div class="gold-divider-animated mx-auto mt-4 mb-6"></div>
       <p class="mb-8 text-[16px] text-text-body md:text-[17px]">
-        Have questions or want to learn more? We'd love to hear from you.
+        Want a demo, running a campaign and have feedback, or just curious? We'd love to hear from
+        you.
       </p>
       <a
         class="inline-flex items-center rounded-xl bg-accent px-10 py-[18px] text-[18px] font-semibold text-[#1a1520] no-underline transition-all duration-200 hover:-translate-y-px hover:bg-accent-hover hover:shadow-[0_4px_28px_rgba(218,160,64,0.25)]"


### PR DESCRIPTION
## Summary
- Use first names only for the three team members (Mark, Daniel, Garrett)
- Tighten the mission statement into shorter, more direct sentences
- Make the "Get in Touch" prompt more specific and inviting

## Changes
`src/pages/about.astro` only.

**Mission**
> ~~We're builders, researchers, and storytellers, experienced in AI and software engineering and united by a shared love of tabletop RPGs.~~
> We're builders, researchers, and storytellers. We know AI and software engineering, and we love tabletop RPGs.

**Get in Touch**
> ~~Have questions or want to learn more? We'd love to hear from you.~~
> Want a demo, running a campaign and have feedback, or just curious? We'd love to hear from you.

## Test plan
- [ ] `npm run dev` and visually verify the About page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)