### PR TITLE
feat: swap header CTA to "Open App" when visitor has an active Clerk session

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -53,6 +53,7 @@ const navLinks = [
       }
       <a
         href="https://app.askloremaster.com"
+        data-app-cta
         class="inline-flex items-center rounded-[10px] border border-accent/40 px-4 py-2 text-[14px] font-semibold text-accent no-underline transition-all duration-200 hover:-translate-y-px hover:border-accent hover:bg-accent/10"
       >
         Log In
@@ -108,6 +109,7 @@ const navLinks = [
       }
       <a
         href="https://app.askloremaster.com"
+        data-app-cta
         class="mobile-nav-link mt-1 inline-flex items-center justify-center rounded-[10px] border border-accent/40 px-4 py-2.5 text-[15px] font-semibold text-accent no-underline transition-colors hover:border-accent hover:bg-accent/10"
       >
         Log In

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -113,6 +113,16 @@ const breadcrumbSchema = breadcrumbLabel ? {
 
     <Footer />
 
+    <script is:inline>
+      // If a Clerk session cookie is present on .askloremaster.com, the visitor
+      // is signed into the app — swap the "Log In" CTA to "Open App".
+      if (document.cookie.split("; ").some((c) => c.startsWith("__session="))) {
+        document.querySelectorAll("[data-app-cta]").forEach((el) => {
+          el.textContent = "Open App";
+        });
+      }
+    </script>
+
     <script>
       // Scroll-triggered reveal animations (site-wide)
       const observer = new IntersectionObserver(

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -114,13 +114,24 @@ const breadcrumbSchema = breadcrumbLabel ? {
     <Footer />
 
     <script is:inline>
-      // If a Clerk session cookie is present on .askloremaster.com, the visitor
-      // is signed into the app — swap the "Log In" CTA to "Open App".
-      if (document.cookie.split("; ").some((c) => c.startsWith("__session="))) {
-        document.querySelectorAll("[data-app-cta]").forEach((el) => {
-          el.textContent = "Open App";
-        });
-      }
+      // Ask Clerk whether the visitor has an active session. The Frontend API
+      // is the same endpoint clerk-js calls under the hood; doing the fetch
+      // directly avoids shipping the full SDK for what is just a label swap.
+      // Requires the production Clerk instance to be live on
+      // clerk.askloremaster.com and www.askloremaster.com to be in Clerk's
+      // allowed origins so the CORS preflight passes.
+      fetch("https://clerk.askloremaster.com/v1/client", {
+        credentials: "include",
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (data?.response?.sessions?.some((s) => s.status === "active")) {
+            document.querySelectorAll("[data-app-cta]").forEach((el) => {
+              el.textContent = "Open App";
+            });
+          }
+        })
+        .catch(() => {});
     </script>
 
     <script>


### PR DESCRIPTION
## Summary
- Header "Log In" button now reads "Open App" when the visitor has an active Clerk session at `app.askloremaster.com`.
- Detection is a tiny inline `fetch` in `BaseLayout` to Clerk's Frontend API (`clerk.askloremaster.com/v1/client`). No SDK, no cookie-name guessing, ~15 lines.
- Both desktop and mobile CTAs are tagged with `data-app-cta` so the script can find them.

## How it works
On every page load, an inline script calls `GET https://clerk.askloremaster.com/v1/client` with `credentials: 'include'`. The browser sends Clerk's session cookies (already scoped to `.askloremaster.com` by the prod custom-domain setup), Clerk validates them, and returns the active sessions. If at least one session is `active`, every element tagged `data-app-cta` has its label swapped to "Open App."

This is the same endpoint `clerk-js` itself queries on boot — we're just doing it directly instead of shipping the ~150KB SDK for a label swap. If we later want a real user menu (avatar, sign-out), we revisit and pull in `@clerk/clerk-js` then.

## Why not the cookie-sniff approach (original commit)
First commit checked `document.cookie` for `__session=`. That was wrong on two counts and got caught in review:

1. `__session` is short-lived (~1 minute, an [XSS-protection design choice](https://clerk.com/docs/guides/secure/best-practices/xss-leak-protection)) — the check would silently stop matching for any returning visitor who hadn't poked the app in the last minute.
2. In production Clerk suffixes cookie names with a hash of the publishable key (`__session_<hash>`), so a literal-string check wouldn't match a real prod cookie either.

The Frontend API call sidesteps both — it asks Clerk directly instead of poking at cookie internals.

## Clerk-side prerequisites
None. Verified by inspecting Clerk's CORS response: a `GET https://clerk.askloremaster.com/v1/client` with `Origin: https://www.askloremaster.com` already returns `access-control-allow-origin: https://www.askloremaster.com` and `access-control-allow-credentials: true`. Sibling subdomains of the configured Clerk root are permitted by default — no dashboard changes required.

## Test plan
- [ ] Signed-out browser: button reads "Log In" on desktop and mobile, no console errors.
- [ ] Sign in at `app.askloremaster.com`, reload the marketing site, confirm button flips to "Open App" within ~few hundred ms of first paint.
- [ ] Sign out, reload, confirm button reverts to "Log In."
- [ ] Devtools → Network: one request to `clerk.askloremaster.com/v1/client`, status 200, no CORS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)