### PR TITLE
feat: cache app-CTA state in a hint cookie to remove the flash

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -77,6 +77,15 @@ const breadcrumbSchema = breadcrumbLabel ? {
     {breadcrumbSchema && <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />}
     {jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
 
+    <script is:inline>
+      // Read the app-CTA hint cookie before <body> parses. If a previous page
+      // load already confirmed the visitor is signed in, the inline script
+      // right after <Header /> can render the CTA as "Open App" before paint.
+      window.__lmAppCta = document.cookie
+        .split("; ")
+        .some((c) => c === "lm_app_cta=1");
+    </script>
+
     <!-- Google Analytics -->
     <script
       async
@@ -107,6 +116,17 @@ const breadcrumbSchema = breadcrumbLabel ? {
 
     <Header currentPath={currentPath} />
 
+    <script is:inline>
+      // Pre-paint label swap: if the hint cookie said the visitor was signed
+      // in on a previous page load, fix the CTAs immediately so the user
+      // doesn't see "Log In" flash to "Open App" after the Clerk fetch lands.
+      if (window.__lmAppCta) {
+        document.querySelectorAll("[data-app-cta]").forEach((el) => {
+          el.textContent = "Open App";
+        });
+      }
+    </script>
+
     <main class="relative z-10">
       <slot />
     </main>
@@ -114,21 +134,32 @@ const breadcrumbSchema = breadcrumbLabel ? {
     <Footer />
 
     <script is:inline>
-      // Ask Clerk whether the visitor has an active session. The Frontend API
-      // is the same endpoint clerk-js calls under the hood; doing the fetch
-      // directly avoids shipping the full SDK for what is just a label swap.
-      // Requires the production Clerk instance to be live on
-      // clerk.askloremaster.com and www.askloremaster.com to be in Clerk's
-      // allowed origins so the CORS preflight passes.
+      // Ask Clerk whether the visitor has an active session, then cache the
+      // answer in a hint cookie on .askloremaster.com so the next page load
+      // can render the right CTA before paint. The cookie carries no auth
+      // value — it's a presentation hint, validated by Clerk on every visit.
       fetch("https://clerk.askloremaster.com/v1/client", {
         credentials: "include",
       })
         .then((r) => (r.ok ? r.json() : null))
         .then((data) => {
-          if (data?.response?.sessions?.some((s) => s.status === "active")) {
+          const signedIn = !!data?.response?.sessions?.some(
+            (s) => s.status === "active",
+          );
+          if (signedIn) {
             document.querySelectorAll("[data-app-cta]").forEach((el) => {
               el.textContent = "Open App";
             });
+            document.cookie =
+              "lm_app_cta=1; Domain=.askloremaster.com; Path=/; Max-Age=2592000; Secure; SameSite=Lax";
+          } else if (data) {
+            // Clerk responded and the visitor is signed out — clear any stale
+            // hint cookie so we don't show "Open App" on the next visit.
+            document.querySelectorAll("[data-app-cta]").forEach((el) => {
+              el.textContent = "Log In";
+            });
+            document.cookie =
+              "lm_app_cta=; Domain=.askloremaster.com; Path=/; Max-Age=0; Secure; SameSite=Lax";
           }
         })
         .catch(() => {});


### PR DESCRIPTION
## Summary
Follow-up to #23. The Clerk-fetch CTA-swap works, but every page load briefly shows "Log In" before flipping to "Open App" — because Astro serves static HTML and the auth check is async. For repeat visitors browsing multiple marketing pages, that's a flash per pageview.

This PR caches the answer in a small cookie so the second pageview onward renders the correct label before paint.

## How it works
1. Synchronous `<head>` script reads `lm_app_cta` cookie before `<body>` parses, stashes the result on `window.__lmAppCta`.
2. Inline script right after `<Header />` reads the global and swaps CTA text to "Open App" if the cache says signed-in. Runs before the browser has finished painting the page → no flash.
3. The existing Clerk fetch runs as before, but now also writes / clears the cookie based on the response:
   - Signed in → set `lm_app_cta=1; Domain=.askloremaster.com; Max-Age=2592000` (30 days)
   - Signed out (and Clerk responded) → clear it
   - Fetch failed → leave whatever was there (avoid backwards flips on transient errors)

The cookie carries no auth value. Clerk validates on every visit. It's purely a presentation hint about which label to paint first.

## Tradeoffs
- **First-ever visit in a session still flashes.** Nothing to cache yet. Acceptable — that's one flash instead of one per page.
- **Stale-positive flash on sign-out.** If a user signs out elsewhere then returns to the marketing site, the cached cookie still says signed-in. First paint shows "Open App"; Clerk fetch corrects it to "Log In" within ~200ms. One inverse flash, then the cookie clears and the next pageview is correct from the start.
- **30-day TTL** is arbitrary; matches the order of magnitude of Clerk's own activity-timestamp cookie. Shorter would be safer (less stale-positive risk), longer would catch more returning visitors. 30 days is a guess.

## Test plan
- [ ] Fresh browser, signed out: button reads "Log In" on first paint of first page. Navigate to a second page: still "Log In" on first paint. No `lm_app_cta` cookie ever set.
- [ ] Sign into `app.askloremaster.com`, visit `www.askloremaster.com`: first paint "Log In", flips to "Open App" after Clerk fetch. Devtools → Application → Cookies: `lm_app_cta=1` now present on `.askloremaster.com`.
- [ ] Navigate to a second marketing page: first paint shows "Open App" with no flash.
- [ ] Sign out in the app, return to marketing site: first paint "Open App" (stale), corrects to "Log In" after fetch. Cookie cleared.
- [ ] Navigate to a third page: first paint "Log In", no flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)