### PR TITLE
fix: apply June 30 marketing copy decisions

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,7 @@ import HeroSessionCarousel from "../components/HeroSessionCarousel.astro";
         Stop taking notes.<br />Stay in the story.
       </h1>
       <p class="hero-cascade mx-auto mt-6 max-w-[50ch] text-[clamp(1.15rem,1rem+0.5vw,1.4rem)] leading-relaxed text-text-body">
-        Play your campaign while Loremaster generates a cinematic recap and tracks your world, session after session.
+        Play your campaign while Loremaster generates a cinematic recap and tracks your adventures, session after session.
       </p>
       <div class="hero-cascade mt-10">
         <a

--- a/src/pages/product.astro
+++ b/src/pages/product.astro
@@ -22,7 +22,7 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       </h1>
       <div class="gold-divider-animated mx-auto mt-5 mb-8"></div>
       <p class="voice text-[clamp(1.1rem,1rem+0.5vw,1.3rem)]">
-        An AI-powered creative companion for tabletop RPG campaigns. Loremaster helps you chronicle
+        An AI scribe for tabletop RPG campaigns. Loremaster helps you chronicle
         your adventures, remember your story, and stay in the moment.
       </p>
       <div class="mt-9">

--- a/src/pages/product.astro
+++ b/src/pages/product.astro
@@ -23,7 +23,7 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       <div class="gold-divider-animated mx-auto mt-5 mb-8"></div>
       <p class="voice text-[clamp(1.1rem,1rem+0.5vw,1.3rem)]">
         An AI scribe for tabletop RPG campaigns. Loremaster helps you chronicle
-        your adventures, remember your story, and stay in the moment.
+        your adventures, remember your story, and pick up right where you left off.
       </p>
       <div class="mt-9">
         <a

--- a/src/pages/product.astro
+++ b/src/pages/product.astro
@@ -22,8 +22,8 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       </h1>
       <div class="gold-divider-animated mx-auto mt-5 mb-8"></div>
       <p class="voice text-[clamp(1.1rem,1rem+0.5vw,1.3rem)]">
-        An AI-powered creative companion for tabletop RPG campaigns. Loremaster helps you manage
-        your world, remember your story, and stay in the moment.
+        An AI-powered creative companion for tabletop RPG campaigns. Loremaster helps you chronicle
+        your adventures, remember your story, and stay in the moment.
       </p>
       <div class="mt-9">
         <a
@@ -175,7 +175,7 @@ import TimelineDemo from "../components/TimelineDemo.astro";
       <!-- Text -->
       <div>
         <h3 class="mb-3 text-[clamp(1.4rem,1.1rem+1.5vw,1.8rem)] font-semibold text-text-primary">
-          Watch your characters grow
+          Watch your characters grow and your story unfold
         </h3>
         <p class="text-[16px] leading-[1.75] text-text-body md:text-[17px]">
           Each entity in the Codex has its own timeline, a visual history of every appearance, every key moment, every turning point. Scroll through a character's journey from introduction to their latest adventure.


### PR DESCRIPTION
Applies the copy changes agreed in the June 30 marketing work session:

- Homepage hero subtitle: "tracks your world" is now "tracks your adventures"
- Product page intro: "manage your world" is now "chronicle your adventures"
- Product page intro: "AI-powered creative companion" is now "AI scribe"
- Product page intro: "stay in the moment" is now "pick up right where you left off" (presence angle already lives on the homepage in Why Loremaster and step 3)
- Product page timeline section heading: now "Watch your characters grow and your story unfold"

Deliberately out of scope (still being mulled):

- The homepage "Loremaster keeps track of your world" echo in Why Loremaster
- Hero headline positive reframe (conflicts with the live "Stay in the story" ad campaign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)