### PR TITLE
Fire Signup conversion event on signup CTA clicks

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -99,6 +99,44 @@ const breadcrumbSchema = breadcrumbLabel ? {
       gtag("js", new Date());
       gtag("config", "G-403NYCTQR9");
     </script>
+    <script is:inline>
+      // Fire the "Signup" conversion event when any link to the app's sign-up
+      // page is clicked. For plain left clicks we hold navigation until gtag
+      // confirms the event was sent (or a timeout passes), because the event
+      // can be lost when the page unloads. The timeout fallback also covers
+      // ad blockers: gtag() is defined inline above, so it always "exists",
+      // but the library that drains dataLayer may never load.
+      document.addEventListener("click", function (event) {
+        var target = event.target instanceof Element ? event.target : null;
+        var link =
+          target &&
+          target.closest('a[href^="https://app.askloremaster.com/sign-up"]');
+        if (!link) return;
+
+        var opensElsewhere =
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey ||
+          event.button !== 0 ||
+          link.target === "_blank";
+        if (opensElsewhere) {
+          // This page stays open, so the event can send normally.
+          gtag("event", "Signup");
+          return;
+        }
+
+        event.preventDefault();
+        var navigated = false;
+        var go = function () {
+          if (navigated) return;
+          navigated = true;
+          window.location.href = link.href;
+        };
+        gtag("event", "Signup", { event_callback: go, event_timeout: 1000 });
+        setTimeout(go, 1100);
+      });
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
## What

Adds Google Ads conversion tracking for signup intent, entirely on the marketing site. A small delegated click listener in `BaseLayout` (next to the existing Google tag) fires a `Signup` gtag event whenever any link to `https://app.askloremaster.com/sign-up` is clicked: header, mobile menu, footer, hero, pricing, and product CTAs are all covered without per-page changes.

## Why

We created a "Signup" conversion action in Google Ads (via the GA4 property's create-with-code event) so the new ads campaign can count signup-button clicks as conversions. Tracking clicks on the site avoids touching the app repo.

## Implementation notes

- Modified clicks (cmd/ctrl/shift/middle, `target="_blank"`) fire the event without touching navigation since the page stays open.
- Plain left clicks hold navigation until gtag confirms the event was sent, with a 1s timeout fallback so buttons never hang when gtag is slow or blocked by an ad blocker.

## After merge

- Click a signup button on the live site and confirm the `Signup` event appears in GA4 Realtime.
- In Google Ads, set the conversion action's counting to "One" and keep it as the campaign's primary goal. Conversion data can take up to 24h to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)